### PR TITLE
Graphs + Mergesort Updates + Quicksort Implementation(s)

### DIFF
--- a/Track4/Graphs Lesson/Graph Search.playground/Contents.swift
+++ b/Track4/Graphs Lesson/Graph Search.playground/Contents.swift
@@ -20,7 +20,7 @@ class GraphNode {
 }
 extension GraphNode: Equatable {
   static func == (lhs: GraphNode, rhs: GraphNode) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode: CustomStringConvertible {
@@ -29,7 +29,7 @@ extension GraphNode: CustomStringConvertible {
   }
 }
 
-class GraphEdge {
+struct GraphEdge {
   let nodeOne: GraphNode
   let nodeTwo: GraphNode
   var weight: Int? = nil
@@ -39,7 +39,7 @@ class GraphEdge {
     self.nodeTwo = nodeTwo
   }
   
-  convenience init(nodeOne: GraphNode, nodeTwo: GraphNode, weight: Int) {
+  init(nodeOne: GraphNode, nodeTwo: GraphNode, weight: Int) {
     self.init(nodeOne: nodeOne, nodeTwo: nodeTwo)
     self.weight = weight
   }
@@ -130,7 +130,7 @@ class GraphNode1a {
 }
 extension GraphNode1a: Equatable {
   static func == (lhs: GraphNode1a, rhs: GraphNode1a) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode1a: CustomStringConvertible {
@@ -176,7 +176,7 @@ class GraphNode1b {
 }
 extension GraphNode1b: Equatable {
   static func == (lhs: GraphNode1b, rhs: GraphNode1b) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode1b: CustomStringConvertible {
@@ -185,7 +185,7 @@ extension GraphNode1b: CustomStringConvertible {
   }
 }
 
-class GraphEdge1b {
+struct GraphEdge1b {
   let nodeOne: GraphNode1b
   let nodeTwo: GraphNode1b
   
@@ -262,7 +262,7 @@ class GraphNode3a {
 }
 extension GraphNode3a: Equatable {
   static func == (lhs: GraphNode3a, rhs: GraphNode3a) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode3a: CustomStringConvertible {
@@ -271,7 +271,7 @@ extension GraphNode3a: CustomStringConvertible {
   }
 }
 
-class GraphEdge3a {
+struct GraphEdge3a {
   let nodeOne: GraphNode3a
   let nodeTwo: GraphNode3a
   
@@ -345,7 +345,7 @@ class GraphNode3b {
 }
 extension GraphNode3b: Equatable {
   static func == (lhs: GraphNode3b, rhs: GraphNode3b) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode3b: CustomStringConvertible {
@@ -354,7 +354,7 @@ extension GraphNode3b: CustomStringConvertible {
   }
 }
 
-class GraphEdge3b {
+struct GraphEdge3b {
   let nodeOne: GraphNode3b
   let nodeTwo: GraphNode3b
   
@@ -451,7 +451,7 @@ class GraphNode6a {
 }
 extension GraphNode6a: Equatable {
   static func == (lhs: GraphNode6a, rhs: GraphNode6a) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode6a: CustomStringConvertible {
@@ -460,7 +460,7 @@ extension GraphNode6a: CustomStringConvertible {
   }
 }
 
-class GraphEdge6a {
+struct GraphEdge6a {
   let nodeOne: GraphNode6a
   let nodeTwo: GraphNode6a
   
@@ -534,7 +534,7 @@ class GraphNode6b {
 }
 extension GraphNode6b: Equatable {
   static func == (lhs: GraphNode6b, rhs: GraphNode6b) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode6b: CustomStringConvertible {
@@ -543,7 +543,7 @@ extension GraphNode6b: CustomStringConvertible {
   }
 }
 
-class GraphEdge6b {
+struct GraphEdge6b {
   let nodeOne: GraphNode6b
   let nodeTwo: GraphNode6b
   
@@ -562,17 +562,17 @@ class Graph6b {
     self.edges = []
   }
   
-  func addEdge(_ nodeOne: GraphNode6b, _ nodeTwo: GraphNode6b, _ bidirectional: Bool) {
+  func addEdge(from nodeOne: GraphNode6b, to nodeTwo: GraphNode6b, isBidirection: Bool) {
     edges.append(GraphEdge6b(nodeOne: nodeOne, nodeTwo: nodeTwo))
     nodeOne.addNeighbor(nodeTwo)
-    if bidirectional {
+    if isBidirection {
       nodeTwo.addNeighbor(nodeOne)
     }
   }
   
   func addEdge(_ nodeOne: GraphNode6b, _ neighboringNodes: [(GraphNode6b, Bool)]) {
     for (node, bidirectional) in neighboringNodes {
-      addEdge(nodeOne, node, bidirectional)
+      addEdge(from: nodeOne, to: node, isBidirection: bidirectional)
     }
   }
   
@@ -620,7 +620,7 @@ class GraphNode7a {
 }
 extension GraphNode7a: Equatable {
   static func == (lhs: GraphNode7a, rhs: GraphNode7a) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode7a: CustomStringConvertible {
@@ -629,7 +629,7 @@ extension GraphNode7a: CustomStringConvertible {
   }
 }
 
-class GraphEdge7a {
+struct GraphEdge7a {
   let nodeOne: GraphNode7a
   let nodeTwo: GraphNode7a
   
@@ -648,17 +648,17 @@ class Graph7a {
     self.edges = []
   }
   
-  func addEdge(_ nodeOne: GraphNode7a, _ nodeTwo: GraphNode7a, _ bidirectional: Bool) {
+  func addEdge(from nodeOne: GraphNode7a, to nodeTwo: GraphNode7a, isBidirection: Bool) {
     edges.append(GraphEdge7a(nodeOne: nodeOne, nodeTwo: nodeTwo))
     nodeOne.addNeighbor(nodeTwo)
-    if bidirectional {
+    if isBidirection {
       nodeTwo.addNeighbor(nodeOne)
     }
   }
   
   func addEdge(_ nodeOne: GraphNode7a, _ neighboringNodes: [(GraphNode7a, Bool)]) {
     for (node, bidirectional) in neighboringNodes {
-      addEdge(nodeOne, node, bidirectional)
+      addEdge(from: nodeOne, to: node, isBidirection: bidirectional)
     }
   }
   
@@ -705,7 +705,7 @@ class GraphNode7b {
 }
 extension GraphNode7b: Equatable {
   static func == (lhs: GraphNode7b, rhs: GraphNode7b) -> Bool {
-      lhs.data == rhs.data && lhs.neighboringNodes == rhs.neighboringNodes
+      return lhs === rhs
   }
 }
 extension GraphNode7b: CustomStringConvertible {
@@ -714,7 +714,7 @@ extension GraphNode7b: CustomStringConvertible {
   }
 }
 
-class GraphEdge7b {
+struct GraphEdge7b {
   let nodeOne: GraphNode7b
   let nodeTwo: GraphNode7b
   var weight: Int? = nil
@@ -724,7 +724,7 @@ class GraphEdge7b {
     self.nodeTwo = nodeTwo
   }
   
-  convenience init(nodeOne: GraphNode7b, nodeTwo: GraphNode7b, weight: Int) {
+  init(nodeOne: GraphNode7b, nodeTwo: GraphNode7b, weight: Int) {
     self.init(nodeOne: nodeOne, nodeTwo: nodeTwo)
     self.weight = weight
   }
@@ -739,17 +739,17 @@ class Graph7b {
     self.edges = []
   }
   
-  func addEdge(_ nodeOne: GraphNode7b, _ nodeTwo: GraphNode7b, _ bidirectional: Bool) {
+  func addEdge(from nodeOne: GraphNode7b, to nodeTwo: GraphNode7b, isBidirection: Bool) {
     edges.append(GraphEdge7b(nodeOne: nodeOne, nodeTwo: nodeTwo))
     nodeOne.addNeighbor(nodeTwo)
-    if bidirectional {
+    if isBidirection {
       nodeTwo.addNeighbor(nodeOne)
     }
   }
   
   func addEdge(_ nodeOne: GraphNode7b, _ neighboringNodes: [(GraphNode7b, Bool)]) {
     for (node, bidirectional) in neighboringNodes {
-      addEdge(nodeOne, node, bidirectional)
+      addEdge(from: nodeOne, to: node, isBidirection: bidirectional)
     }
   }
   

--- a/Track5/Merge Sort/Merge Sort.playground/Contents.swift
+++ b/Track5/Merge Sort/Merge Sort.playground/Contents.swift
@@ -1,29 +1,53 @@
 func merge(leftArray: [Int], rightArray: [Int]) -> [Int] {
-    var mergedArray = [Int]()
-    var leftCopy = leftArray
-    var rightCopy = rightArray
-
-    while leftCopy.count > 0 && rightCopy.count > 0 {
-        let nextValue = leftCopy.first! < rightCopy.first! ? leftCopy.removeFirst() : rightCopy.removeFirst()
-        mergedArray.append(nextValue)
+  var leftIndex = 0
+  var rightIndex = 0
+  var orderedArray: [Int] = []
+  
+  while leftIndex < leftArray.count && rightIndex < rightArray.count {
+    let leftElement = leftArray[leftIndex]
+    let rightElement = rightArray[rightIndex]
+    
+    if leftElement < rightElement {
+      orderedArray.append(leftElement)
+      leftIndex += 1
+    } else if leftElement > rightElement {
+      orderedArray.append(rightElement)
+      rightIndex += 1
+    } else {
+      orderedArray.append(leftElement)
+      leftIndex += 1
+      orderedArray.append(rightElement)
+      rightIndex += 1
     }
+  }
+    
+  while leftIndex < leftArray.count {
+    orderedArray.append(leftArray[leftIndex])
+    leftIndex += 1
+  }
 
-    return mergedArray + leftCopy + rightCopy
+  while rightIndex < rightArray.count {
+    orderedArray.append(rightArray[rightIndex])
+    rightIndex += 1
+  }
+  
+  return orderedArray
 }
 
 func mergeSort(_ inputArray: [Int]) -> [Int] {
-    guard inputArray.count > 1 else {
-        return inputArray
-    }
+  guard inputArray.count > 1 else {
+      return inputArray
+  }
 
-    let midIndex = inputArray.count/2
-    let leftArray = Array(inputArray[0..<midIndex])
-    let rightArray = Array(inputArray[midIndex..<inputArray.count])
+  let midIndex = inputArray.count/2
+  let leftArray = Array(inputArray[0..<midIndex])
+  let rightArray = Array(inputArray[midIndex..<inputArray.count])
+  print(leftArray, rightArray)
 
-    let leftMerge = mergeSort(leftArray)
-    let rightMerge = mergeSort(rightArray)
+  let leftMerge = mergeSort(leftArray)
+  let rightMerge = mergeSort(rightArray)
 
-    return merge(leftArray: leftMerge, rightArray: rightMerge)
+  return merge(leftArray: leftMerge, rightArray: rightMerge)
 }
 
 var countBackwards = [10, 8, 3, 1, -5]

--- a/Track5/Quick Sort/Quick Sort.playground/Contents.swift
+++ b/Track5/Quick Sort/Quick Sort.playground/Contents.swift
@@ -1,0 +1,51 @@
+/*
+ Although this functions the pivot correctly, it doens't technically apply the "Space Complexity" that QuickSort is known for (in-place sorting vs mergesort's out-of-place sorting)
+ Also,looking at the run time, this may run in O(n log n) but the actual execution is less efficient than #2. Just some considerations.
+ */
+// 1.
+
+func quicksort1(_ array: [Int]) -> [Int] {
+  guard array.count > 1 else { return array }
+
+  let pivot = array[array.count/2]
+  let less = array.filter { $0 < pivot }
+  let equal = array.filter { $0 == pivot }
+  let greater = array.filter { $0 > pivot }
+
+  return quicksort1(less) + equal + quicksort1(greater)
+}
+
+var array1 = [1, 9, 2, 8, 3, 7, 4, 6, 5]
+let sorted1 = quicksort1(array1)
+print(array1)
+print(sorted1)
+
+
+// 2.
+func quicksort2(_ array: inout [Int], from start: Int, to end: Int) {
+  if start < end {
+    let partititon = partition(&array, from: start, to: end)
+    quicksort2(&array, from: start, to: partititon-1)
+    quicksort2(&array, from: partititon+1, to: end)
+  }
+}
+
+func partition(_ array: inout [Int], from start: Int, to end: Int) -> Int {
+  let pivot = array[end]
+  
+  var lessThanPivotIncrementer = start
+  for value in start..<end {
+    if array[value] <= pivot {
+      array.swapAt(lessThanPivotIncrementer, value)
+      lessThanPivotIncrementer += 1
+    }
+  }
+  
+  array.swapAt(lessThanPivotIncrementer, end)
+  return lessThanPivotIncrementer
+}
+
+var array2 = [1, 9, 2, 8, 3, 7, 4, 6, 5]
+print(array2)
+quicksort2(&array2, from: 0, to: array2.count-1)
+print(array2)

--- a/Track5/Quick Sort/Quick Sort.playground/contents.xcplayground
+++ b/Track5/Quick Sort/Quick Sort.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' buildActiveScheme='true' importAppTypes='true'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Track5/Quick Sort/Quick Sort.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Track5/Quick Sort/Quick Sort.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
Mergesort:
- The code is a bit longer with the following modifications
-- removed `removeFirst()`
-- I use "pointers" to track adding elements in the correct order

- Graphs:
-- Equatable comparisons use `===` comparing instances vs instance data
-- Changed `graphEdge` to a structure instead of class
-- Changed `bidirectional` to `isBidirection`

- Quicksort:
-- Added 2 quicksort implementations to look over.
--- The first implementation is the most common online but doesn't truly capture the advantages that quicksort provides
--- The second implementation is a bit more advanced but has the right idea and run time is more efficient.